### PR TITLE
fixed external templates

### DIFF
--- a/mdninja/__init__.py
+++ b/mdninja/__init__.py
@@ -21,12 +21,12 @@ class MdNinja(object):
             env = Environment(loader=PackageLoader('mdninja', 'templates'))
             template = env.get_template('default.html')
         else:
-            path = Path(self.args.outfile).parts
+            path = Path(self.args.template).resolve().parts
             tfile = path[-1]
             print('tfile: ', tfile)
             print('-1: ', os.path.join(*path[:-1]))
             tdir = os.path.join(*path[:-1])
-            if not os.path.isfile(self.args.outfile):
+            if not os.path.isfile(self.args.template):
                 print('template is not a file')
                 sys.exit(0)
             env = Environment(loader=FileSystemLoader(tdir))


### PR DESCRIPTION
External templates were broken due to wrong variable usage. Furthermore, I added `resolve()` to `Path` to allow using templates within same directory.